### PR TITLE
feat: add PERP to erc20select

### DIFF
--- a/frontend/src/components/CreateGift/Erc20Select.tsx
+++ b/frontend/src/components/CreateGift/Erc20Select.tsx
@@ -116,6 +116,14 @@ export const erc20TokensData = [
     name: "Small Love Potion",
     symbol: "SLP",
   },
+  {
+    address: "0xbC396689893D065F41bc2C6EcbeE5e0085233447",
+    chainId: 1,
+    decimals: 18,
+    logoURI: "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbC396689893D065F41bc2C6EcbeE5e0085233447/logo.png",
+    name: "Perpetual Protocol",
+    symbol: "PERP",
+  },
 ];
 
 const Erc20Select: React.FunctionComponent<IProps> = (props) => {


### PR DESCRIPTION
Hey wondering if we can add PERP ( https://perp.exchange / https://etherscan.io/token/0xbC396689893D065F41bc2C6EcbeE5e0085233447 ) to yGift UI? 

We plan to use yGift soon, and it'd be easier for the users to use the same UI instead of another one forked by us. Thanks!